### PR TITLE
Make library compile if libtest is unavailable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ include_directories(${LIBWFA_DIR})
 add_subdirectory(libwfa)
 
 
-if (${HAVE_LIBTEST})
+if (HAVE_LIBTEST)
 	add_subdirectory(tests)
-else (${HAVE_LIBTEST})
+else (HAVE_LIBTEST)
 	Message(WARNING "libtest not found. Just compiling the bare library, but no tests.")
-endif(${HAVE_LIBTEST})
+endif(HAVE_LIBTEST)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.6)
 project(LIBWFA)
 
 get_filename_component(LIBTEST_DIR ${LIBWFA_SOURCE_DIR}/../libtest ABSOLUTE)
+if (IS_DIRECTORY ${LIBTEST_DIR})
+	set(HAVE_LIBTEST TRUE)
+else (IS_DIRECTORY ${LIBTEST_DIR})
+	set(HAVE_LIBTEST FALSE)
+endif (IS_DIRECTORY ${LIBTEST_DIR}) 
+
 set(LIBWFA_DIR ${LIBWFA_SOURCE_DIR})
 
 include(${LIBWFA_DIR}/cmake/DepsLibWFA.txt)
@@ -9,5 +15,11 @@ include(${LIBWFA_DIR}/cmake/DepsLibWFA.txt)
 include_directories(${LIBWFA_DIR})
 
 add_subdirectory(libwfa)
-add_subdirectory(tests)
+
+
+if (${HAVE_LIBTEST})
+	add_subdirectory(tests)
+else (${HAVE_LIBTEST})
+	Message(WARNING "libtest not found. Just compiling the bare library, but no tests.")
+endif(${HAVE_LIBTEST})
 


### PR DESCRIPTION
Partly fixes issue #1. If libtest is unavailable, only libwfa, but not the tests are compiled.