### PR TITLE
CMake: Install libwfa_molcas

### DIFF
--- a/libwfa/CMakeLists.txt
+++ b/libwfa/CMakeLists.txt
@@ -137,6 +137,11 @@ if(MOLCAS_LIB)
   project(libwfa CXX)
   add_definitions ( -DARMA_BLAS_LONG )
   add_library(wfa_molcas ${SRC} ${HEADERS} ${MOLCAS_HDR} ${MOLCAS_SRC})
+  install (TARGETS wfa_molcas
+           RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+           LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+           ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  )
 else()
     set(TARGETS wfa)
     add_library(wfa ${SRC} ${HEADERS})


### PR DESCRIPTION
Since Molcas includes libwfa in CMake as a subdirectory, installation of the targets must be handled here.

See https://gitlab.com/Molcas/OpenMolcas/issues/33 and https://cmake.org/Bug/view.php?id=14444